### PR TITLE
config: restore rtpengine sample interfaces file

### DIFF
--- a/config/rtpengine/interfaces
+++ b/config/rtpengine/interfaces
@@ -1,0 +1,1 @@
+INTERFACES="--interface=SAMPLE/127.0.0.1"


### PR DESCRIPTION
This file has been removed and it's required as conffile for debian package